### PR TITLE
Add unit to GPU_POWER header

### DIFF
--- a/src/gpu/nvidia.rs
+++ b/src/gpu/nvidia.rs
@@ -73,7 +73,7 @@ pub fn dump_gpu_stat(device: nvml_wrapper::Device, results: &mut HashMap<String,
 
     match gpustat.power {
         Ok(power) => {
-            let key = format!("GPU{}_POWER", index).to_string();
+            let key = format!("GPU{}_POWER (mWatts)", index).to_string();
             results.insert(key, power.into());
         }
         Err(_) => {}


### PR DESCRIPTION
Had to look [here](https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g7ef7dff0ff14238d08a19ad7fb23fc87) for the unit (milliWatts) of the GPU_POWER measurement on nvidia. To keep consistent with the other headers, I've added it to the respective header. 