### PR TITLE
Draft: Add time_delta and CPU power calculation

### DIFF
--- a/src/cpu/amd.rs
+++ b/src/cpu/amd.rs
@@ -10,7 +10,7 @@ const AMD_MSR_FID: u32 = 0xC0010293;
 
 const AMD_ENERGY_UNIT_MASK: u32 = 0x1F00;
 
-pub fn get_amd_cpu_cunter(sys: &mut System, results: &mut HashMap<String, f64>) {
+pub fn get_amd_cpu_cunter(sys: &mut System, results: &mut HashMap<String, f64>, time_delta: u32) {
     #[cfg(target_os = "linux")]
     let nb_core = get_number_cores(sys).unwrap() as u32;
     #[cfg(target_os = "windows")]
@@ -43,6 +43,12 @@ pub fn get_amd_cpu_cunter(sys: &mut System, results: &mut HashMap<String, f64>) 
                 format!("CORE{}_ENERGY (J)", core),
                 core_energy_raw as f64 * energy_unit_d,
             );
+            if results.contains_key("CPU_ENERGY (J)") {
+                results.insert(
+                    format!("CORE_ENERGY (W)", ),
+                    (results["CPU_ENERGY (J)"].last() - package_raw as f64 * energy_unit_d) * (1000 / time_delta) as f64,
+                );
+            }
             results.insert(
                 format!("CPU_ENERGY (J)"),
                 package_raw as f64 * energy_unit_d,

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -26,7 +26,7 @@ pub fn get_cpu_usage(sys: &mut System, results: &mut HashMap<String, f64>) {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn get_cpu_cunter(sys: &mut System, results: &mut HashMap<String, f64>) {
+pub fn get_cpu_cunter(sys: &mut System, results: &mut HashMap<String, f64>, time_delta: u32) {
     sys.refresh_cpu();
 
     let vendor = sys.global_cpu_info().vendor_id();
@@ -34,11 +34,11 @@ pub fn get_cpu_cunter(sys: &mut System, results: &mut HashMap<String, f64>) {
     if vendor == "GenuineIntel" {
         intel::get_intel_cpu_cunter(results);
     } else if vendor == "AuthenticAMD" {
-        amd::get_amd_cpu_cunter(sys, results);
+        amd::get_amd_cpu_cunter(sys, results, time_delta);
     }
 }
 
 #[cfg(target_os = "macos")]
-pub fn get_cpu_cunter(sys: &mut System, results: &mut HashMap<String, f64>) {
+pub fn get_cpu_cunter(sys: &mut System, results: &mut HashMap<String, f64>, time_delta: u32) {
     apple::get_apple_cpu_cunter(results);
 }


### PR DESCRIPTION
An addition I would like to propose is the CPU Power option, such that I can include it with the GPU results and don't have to manually implement it afterwards. 

I haven't got the time to fully implement this yet, so this code is untested and probably broken, however, I think the idea makes sense because from what I understand gives `--summary` a total consumption of the command, while this provides it over time. 

Could you indicate if this makes sense? Then I will continue to try to make it work. Thanks!