### PR TITLE
Patch windows init

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,27 +25,28 @@ Depending on your hardware you need different dependencies.
 
 ### Windows
 
-Install LibreHardwareMonitor to access the CPU registry
+Install LibreHardwareMonitor to access the CPU registry.
 
+
+In an elevated (Administrator) command line (e.g. cmd.exe):
 ```
 Create:
-
-`sc create rapl type= kernel binPath= "<path_to_LibreHardwareMonitor.sys>"`
+sc create rapl type=kernel binPath="<absolute_path_to_LibreHardwareMonitor.sys>"
 
 Start:
-
-`sc start rapl`
+sc start rapl
 
 Stop:
-
-`sc stop rapl`
+sc stop rapl
 
 Delete:
+sc delete rapl
 
-`sc delete rapl`
-
-cargo build;
+Build:
+cargo build -r
 ```
+
+> For PowerShell use `sc.exe` instead of `sc`.
 
 ### Linux
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,9 @@ fn main() {
         );
     }
 
+    #[cfg(target_os = "windows")]
+    cpu::msr::windows::start_rapl_impl();
+
     let mut sys = System::new_all();
     sys.refresh_all();
     std::thread::sleep(System::MINIMUM_CPU_UPDATE_INTERVAL);

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,8 +153,8 @@ fn main() {
                 }
             }
         }
-        Err(_) => {
-            eprintln!("Failed to execute command.");
+        Err(err) => {
+            eprintln!("Failed to execute command: {}", err);
             exit(1);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,8 +73,8 @@ fn main() {
         );
     }
 
-    #[cfg(target_os = "windows")]
-    cpu::msr::windows::start_rapl_impl();
+    #[cfg(not(target_os = "macos"))]
+    cpu::msr::start_rapl();
 
     let mut sys = System::new_all();
     sys.refresh_all();
@@ -94,9 +94,6 @@ fn main() {
     match cmd {
         Ok(mut child) => {
             let start_time = Instant::now();
-
-            #[cfg(not(target_os = "macos"))]
-            cpu::msr::start_rapl();
 
             collect(&mut sys, collect_gpu, child.id(), &mut results);
             print_header(&results, sep, &mut output);


### PR DESCRIPTION
Call start_rapl_impl() for Windows targets.
Update readme with instructions for Windows.
Log error for unknown commands.