### PR TITLE
Resolve issue with Intel CPU measurement using the wrong units

### DIFF
--- a/src/cpu/amd.rs
+++ b/src/cpu/amd.rs
@@ -10,7 +10,7 @@ const AMD_MSR_FID: u32 = 0xC0010293;
 
 const AMD_ENERGY_UNIT_MASK: u32 = 0x1F00;
 
-pub fn get_amd_cpu_cunter(sys: &mut System, results: &mut HashMap<String, f64>) {
+pub fn get_amd_cpu_counter(sys: &mut System, results: &mut HashMap<String, f64>) {
     #[cfg(target_os = "linux")]
     let nb_core = get_number_cores(sys).unwrap() as u32;
     #[cfg(target_os = "windows")]

--- a/src/cpu/apple.rs
+++ b/src/cpu/apple.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use smc::SMC;
 
 #[cfg(target_os = "macos")]
-pub fn get_apple_cpu_cunter(results: &mut HashMap<String, f64>) {
+pub fn get_apple_cpu_counter(results: &mut HashMap<String, f64>) {
     let smc = SMC::new().unwrap();
     // does not work on M1
     match smc.read_key::<f32>("PCTR".into()) {

--- a/src/cpu/intel.rs
+++ b/src/cpu/intel.rs
@@ -11,19 +11,20 @@ use super::msr::read_msr_on_core;
 
 pub const UJ_TO_J_FACTOR: f64 = 1000000.;
 
-pub const MSR_RAPL_POWER_UNIT: u32 = 0x00000606;
+pub const MSR_RAPL_POWER_UNIT: u32 = 0x606;
 pub const MSR_RAPL_PKG_ENERGY_STAT: u32 = 0x611;
 
 pub const INTEL_MSR_RAPL_PP0: u32 = 0x639;
 pub const INTEL_MSR_RAPL_PP1: u32 = 0x641;
 pub const INTEL_MSR_RAPL_DRAM: u32 = 0x619;
-const INTEL_TIME_UNIT_MASK: u64 = 0xF000;
-const INTEL_ENGERY_UNIT_MASK: u32 = 0x1F00;
-const INTEL_POWER_UNIT_MASK: u32 = 0x0F;
 
-const INTEL_TIME_UNIT_OFFSET: u32 = 0x10;
-const INTEL_ENGERY_UNIT_OFFSET: u32 = 0x08;
-const INTEL_POWER_UNIT_OFFSET: u32 = 0;
+const INTEL_TIME_UNIT_MASK: u64 = 0xF0000; // Bits 19:16
+const INTEL_ENGERY_UNIT_MASK: u64 = 0x1F00; // Bits 12:8
+const INTEL_POWER_UNIT_MASK: u64 = 0x0F; // Bits 3:0
+
+const INTEL_TIME_UNIT_OFFSET: u32 = 0x10; // Offset 16
+const INTEL_ENGERY_UNIT_OFFSET: u32 = 0x08; // Offset 8
+const INTEL_POWER_UNIT_OFFSET: u32 = 0; // Offset 0
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RAPLData {
@@ -201,40 +202,67 @@ pub fn read_power_limit(file_path: String) -> f64 {
 }
 
 pub fn get_intel_cpu_cunter(results: &mut HashMap<String, f64>) {
+    // --- Read using Power Capping Framework (Linux only) ---
     // let zone = setup_rapl_data();
-    let start_time = Instant::now();
-    let mut prev_time = Instant::now();
-    let mut now = Instant::now();
-
+    // let start_time = Instant::now();
+    // let mut prev_time = Instant::now();
+    // let mut now = Instant::now();
     //    let mut data =
     //      calculate_power_metrics(zone.get(0).unwrap().to_owned(), now, start_time, prev_time);
 
     unsafe {
+        // --- Read using MSR ---
+
+        // TODO: these values are constant, read them once and store them
+        // The MSR only store integer values, but they represent floating point values.
+        // The MSR_RAPL_POWER_UNIT MSR contains the units for the RAPL MSRs for a specific intel chip.
+        // it contains three units, which represent the time, power, and energy increments in the RAPL MSRs.
         let core_energy_units: u64 = read_msr_on_core(MSR_RAPL_POWER_UNIT, 0).unwrap();
-        let energy_unit: u64 = (core_energy_units & INTEL_TIME_UNIT_MASK) >> 8;
+        
+        // First, we extract the individual units using the masks and offsets.
+        // Then we convert them to floating point values using the formula 0.5^x.
+        // See Section 14.9.1 of the Intel Architectures Software Developer's Manual (Vol 3B) for more information.
+
+        // Unused at the moment:
+        /*
+        let time_unit: u64 = (core_energy_units & INTEL_TIME_UNIT_MASK) >> INTEL_TIME_UNIT_OFFSET;
+        let time_unit_d = 0.5f64.powf(time_unit as f64);
+
+        let power_unit: u64 = (core_energy_units & INTEL_POWER_UNIT_MASK) >> INTEL_POWER_UNIT_OFFSET;
+        let power_unit_d = 0.5f64.powf(time_unit as f64);
+         */
+
+        let energy_unit: u64 = (core_energy_units & INTEL_ENGERY_UNIT_MASK) >> INTEL_ENGERY_UNIT_OFFSET;
         let energy_unit_d = 0.5f64.powf(energy_unit as f64);
 
+        // Read the RAPL MSRs
+        // PP0 = CPU cores energy consumption
         let pp0 = read_msr_on_core(INTEL_MSR_RAPL_PP0, 0).expect("failed to read PP0");
+        // PP1 = Integrated GPU energy consumption
         let pp1 = read_msr_on_core(INTEL_MSR_RAPL_PP1, 0).expect("failed to read PP1");
+        // PKG = CPU socket energy consumption
         let pkg = read_msr_on_core(MSR_RAPL_PKG_ENERGY_STAT, 0)
             .expect("failed to read RAPL_PKG_ENERGY_STAT");
+        // DRAM = Energy consumed by the DRAM for the chip's memory controller.
         let dram = read_msr_on_core(INTEL_MSR_RAPL_DRAM, 0).expect("failed to read DRAM");
-
+        
+        // convert the integer values to floating point values using the energy unit
+        // and store them in the results hashmap
         results.insert(
             format!("DRAM_ENERGY (J)"),
-            dram as f64 * energy_unit_d / UJ_TO_J_FACTOR,
+            dram as f64 * energy_unit_d,
         );
         results.insert(
             format!("PACKAGE_ENERGY (J)"),
-            pkg as f64 * energy_unit_d / UJ_TO_J_FACTOR,
+            pkg as f64 * energy_unit_d,
         );
         results.insert(
             format!("PP0_ENERGY (J)"),
-            pp0 as f64 * energy_unit_d / UJ_TO_J_FACTOR,
+            pp0 as f64 * energy_unit_d,
         );
         results.insert(
             format!("PP1_ENERGY (J)"),
-            pp1 as f64 * energy_unit_d / UJ_TO_J_FACTOR,
+            pp1 as f64 * energy_unit_d,
         );
     }
 }

--- a/src/cpu/intel.rs
+++ b/src/cpu/intel.rs
@@ -9,11 +9,8 @@ use std::time::Instant;
 
 use super::msr::read_msr_on_core;
 
-pub const UJ_TO_J_FACTOR: f64 = 1000000.;
-
-pub const MSR_RAPL_POWER_UNIT: u32 = 0x606;
-pub const MSR_RAPL_PKG_ENERGY_STAT: u32 = 0x611;
-
+pub const INTEL_MSR_RAPL_POWER_UNIT: u32 = 0x606;
+pub const INTEL_MSR_RAPL_PKG: u32 = 0x611;
 pub const INTEL_MSR_RAPL_PP0: u32 = 0x639;
 pub const INTEL_MSR_RAPL_PP1: u32 = 0x641;
 pub const INTEL_MSR_RAPL_DRAM: u32 = 0x619;
@@ -26,211 +23,20 @@ const INTEL_TIME_UNIT_OFFSET: u32 = 0x10; // Offset 16
 const INTEL_ENGERY_UNIT_OFFSET: u32 = 0x08; // Offset 8
 const INTEL_POWER_UNIT_OFFSET: u32 = 0; // Offset 0
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RAPLData {
-    #[serde(skip_serializing, skip_deserializing)]
-    pub path: String,
-    pub zone: String,
-    pub time_elapsed: f64,
-    pub power_j: f64,
-    pub watts: f64,
-    pub watts_since_last: f64,
-    pub start_power: f64,
-    pub prev_power: f64,
-    pub prev_power_reading: f64,
-    pub temp: f64,
-}
-
-#[derive(Debug)]
-pub struct RAPLZone {
-    pub path: String,
-    pub name: String,
-}
-
-// https://github.com/cs-21-pt-9-01/rapl.rs/blob/master/src/common.rs
-pub fn list_rapl() -> Vec<RAPLZone> {
-    let base_path = "/sys/devices/virtual/powercap/intel-rapl/";
-    let cpus = fs::read_dir(base_path).unwrap();
-    let mut zones: Vec<RAPLZone> = vec![];
-
-    for cpu in cpus {
-        let pkg = parse_rapl_dir(cpu.unwrap());
-        match pkg {
-            Some(x) => zones.push(x),
-            None => continue,
-        }
-
-        let path = &zones.last().unwrap().path;
-        let pkg = fs::read_dir(path).unwrap();
-
-        for core in pkg {
-            let core_zone = parse_rapl_dir(core.unwrap());
-            match core_zone {
-                Some(x) => zones.push(x),
-                None => continue,
-            }
-        }
-    }
-
-    return zones;
-}
-
-fn parse_rapl_dir(item: DirEntry) -> Option<RAPLZone> {
-    let cleaned_item_name = item
-        .path()
-        .display()
-        .to_string()
-        .split("/")
-        .last()
-        .unwrap()
-        .to_owned();
-
-    if !cleaned_item_name.contains("intel-rapl") {
-        return None;
-    }
-
-    let item_path = item.path().display().to_string();
-    let item_name_data = fs::read(format!("{}/name", item_path))
-        .expect(format!("Couldn't read file {}/name", item_path).as_str());
-    let item_name = String::from_utf8_lossy(&item_name_data);
-
-    return Some(RAPLZone {
-        path: item.path().display().to_string(),
-        name: item_name.to_string().replace("\n", ""),
-    });
-}
-
-pub fn setup_rapl_data() -> Vec<RAPLData> {
-    let sys_zones = list_rapl();
-    let mut zones: Vec<RAPLData> = vec![];
-
-    for z in sys_zones {
-        let start_power = read_power(z.path.to_owned());
-        let data = RAPLData {
-            path: z.path,
-            zone: z.name,
-            time_elapsed: 0.,
-            power_j: 0.,
-            watts: 0.,
-            watts_since_last: 0.,
-            start_power,
-            prev_power: 0.,
-            prev_power_reading: start_power,
-            temp: 0.,
-        };
-        zones.push(data);
-    }
-
-    return zones;
-}
-
-pub fn calculate_power_metrics(
-    zone: RAPLData,
-    now: Instant,
-    start_time: Instant,
-    prev_time: Instant,
-) -> RAPLData {
-    let cur_power_j = read_power(zone.path.to_owned());
-
-    #[allow(unused_assignments)]
-    let mut power_j = 0.;
-    let mut watts = 0.;
-    let mut watts_since_last = 0.;
-
-    let power_limit = read_power_limit(zone.path.to_owned());
-
-    // if RAPL overflow has occurred
-    // or if we have done a full RAPL cycle
-    if zone.start_power >= cur_power_j || zone.power_j >= power_limit {
-        // if our previous reading was pre-overflow, we simply add the new reading
-        // otherwise we add the difference
-        if zone.prev_power_reading > cur_power_j {
-            power_j = (power_limit - zone.prev_power_reading) + cur_power_j + zone.power_j;
-        } else {
-            power_j = (cur_power_j - zone.prev_power_reading) + zone.power_j;
-        }
-    } else {
-        power_j = cur_power_j - zone.start_power;
-    }
-
-    let sample_time = now.duration_since(start_time).as_secs_f64();
-    if sample_time > 0. {
-        watts = power_j / sample_time;
-    }
-
-    if prev_time > start_time {
-        watts_since_last = (power_j - zone.power_j) / now.duration_since(prev_time).as_secs_f64();
-    }
-
-    return RAPLData {
-        path: zone.path,
-        zone: zone.zone,
-        time_elapsed: start_time.elapsed().as_secs_f64(),
-        power_j,
-        watts,
-        watts_since_last,
-        start_power: zone.start_power,
-        prev_power: zone.power_j,
-        prev_power_reading: cur_power_j,
-        temp: 0.,
-    };
-}
-
-pub fn reading_as_float(reading: &[u8]) -> f64 {
-    let mut reading = String::from_utf8(reading.to_vec()).unwrap();
-    reading.pop();
-    return reading.parse::<f64>().unwrap();
-}
-
-pub fn read_power(file_path: String) -> f64 {
-    let power = fs::read(format!("{}/energy_uj", file_path.to_owned()))
-        .expect(format!("Couldn't read file {}/energy_uj", file_path.to_owned()).as_str());
-
-    return reading_as_float(&power) / UJ_TO_J_FACTOR;
-}
-
-pub fn read_power_limit(file_path: String) -> f64 {
-    let limit = fs::read(format!("{}/max_energy_range_uj", file_path.to_owned())).expect(
-        format!(
-            "Couldn't read file {}/max_energy_range_uj",
-            file_path.to_owned()
-        )
-        .as_str(),
-    );
-
-    return reading_as_float(&limit) / UJ_TO_J_FACTOR;
-}
 
 pub fn get_intel_cpu_counter(results: &mut HashMap<String, f64>) {
-    // --- Read using Power Capping Framework (Linux only) ---
-    // let zone = setup_rapl_data();
-    // let start_time = Instant::now();
-    // let mut prev_time = Instant::now();
-    // let mut now = Instant::now();
-    //    let mut data =
-    //      calculate_power_metrics(zone.get(0).unwrap().to_owned(), now, start_time, prev_time);
-
     unsafe {
         // --- Read using MSR ---
 
         // TODO: these values are constant, read them once and store them
         // The MSR only store integer values, but they represent floating point values.
-        // The MSR_RAPL_POWER_UNIT MSR contains the units for the RAPL MSRs for a specific intel chip.
+        // The INTEL_MSR_RAPL_POWER_UNIT MSR contains the units for the RAPL MSRs for a specific intel chip.
         // it contains three units, which represent the time, power, and energy increments in the RAPL MSRs.
-        let core_energy_units: u64 = read_msr_on_core(MSR_RAPL_POWER_UNIT, 0).unwrap();
+        let core_energy_units: u64 = read_msr_on_core(INTEL_MSR_RAPL_POWER_UNIT, 0).unwrap();
         
         // First, we extract the individual units using the masks and offsets.
         // Then we convert them to floating point values using the formula 0.5^x.
         // See Section 14.9.1 of the Intel Architectures Software Developer's Manual (Vol 3B) for more information.
-
-        // Unused at the moment:
-        /*
-        let time_unit: u64 = (core_energy_units & INTEL_TIME_UNIT_MASK) >> INTEL_TIME_UNIT_OFFSET;
-        let time_unit_d = 0.5f64.powf(time_unit as f64);
-
-        let power_unit: u64 = (core_energy_units & INTEL_POWER_UNIT_MASK) >> INTEL_POWER_UNIT_OFFSET;
-        let power_unit_d = 0.5f64.powf(time_unit as f64);
-         */
 
         let energy_unit: u64 = (core_energy_units & INTEL_ENGERY_UNIT_MASK) >> INTEL_ENGERY_UNIT_OFFSET;
         let energy_unit_d = 0.5f64.powf(energy_unit as f64);
@@ -241,7 +47,7 @@ pub fn get_intel_cpu_counter(results: &mut HashMap<String, f64>) {
         // PP1 = Integrated GPU energy consumption
         let pp1 = read_msr_on_core(INTEL_MSR_RAPL_PP1, 0).expect("failed to read PP1");
         // PKG = CPU socket energy consumption
-        let pkg = read_msr_on_core(MSR_RAPL_PKG_ENERGY_STAT, 0)
+        let pkg = read_msr_on_core(INTEL_MSR_RAPL_PKG, 0)
             .expect("failed to read RAPL_PKG_ENERGY_STAT");
         // DRAM = Energy consumed by the DRAM for the chip's memory controller.
         let dram = read_msr_on_core(INTEL_MSR_RAPL_DRAM, 0).expect("failed to read DRAM");

--- a/src/cpu/intel.rs
+++ b/src/cpu/intel.rs
@@ -201,7 +201,7 @@ pub fn read_power_limit(file_path: String) -> f64 {
     return reading_as_float(&limit) / UJ_TO_J_FACTOR;
 }
 
-pub fn get_intel_cpu_cunter(results: &mut HashMap<String, f64>) {
+pub fn get_intel_cpu_counter(results: &mut HashMap<String, f64>) {
     // --- Read using Power Capping Framework (Linux only) ---
     // let zone = setup_rapl_data();
     // let start_time = Instant::now();

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -26,19 +26,19 @@ pub fn get_cpu_usage(sys: &mut System, results: &mut HashMap<String, f64>) {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn get_cpu_cunter(sys: &mut System, results: &mut HashMap<String, f64>) {
+pub fn get_cpu_counter(sys: &mut System, results: &mut HashMap<String, f64>) {
     sys.refresh_cpu();
 
     let vendor = sys.global_cpu_info().vendor_id();
     #[cfg(not(target_os = "macos"))]
     if vendor == "GenuineIntel" {
-        intel::get_intel_cpu_cunter(results);
+        intel::get_intel_cpu_counter(results);
     } else if vendor == "AuthenticAMD" {
-        amd::get_amd_cpu_cunter(sys, results);
+        amd::get_amd_cpu_counter(sys, results);
     }
 }
 
 #[cfg(target_os = "macos")]
-pub fn get_cpu_cunter(sys: &mut System, results: &mut HashMap<String, f64>) {
-    apple::get_apple_cpu_cunter(results);
+pub fn get_cpu_counter(sys: &mut System, results: &mut HashMap<String, f64>) {
+    apple::get_apple_cpu_counter(results);
 }

--- a/src/gpu/amd.rs
+++ b/src/gpu/amd.rs
@@ -1,3 +1,3 @@
 use std::collections::HashMap;
 
-pub fn get_amd_gpu_cunter(results: &mut HashMap<String, f64>) {}
+pub fn get_amd_gpu_counter(results: &mut HashMap<String, f64>) {}

--- a/src/gpu/apple.rs
+++ b/src/gpu/apple.rs
@@ -4,7 +4,7 @@ use smc::SMC;
 use std::collections::HashMap;
 
 #[cfg(target_os = "macos")]
-pub fn get_apple_gpu_cunter(results: &mut HashMap<String, f64>) {
+pub fn get_apple_gpu_counter(results: &mut HashMap<String, f64>) {
     let smc = SMC::new().unwrap();
     for key in [
         // Intel

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -5,17 +5,17 @@ mod nvidia;
 use std::collections::HashMap;
 
 #[cfg(not(target_os = "macos"))]
-use amd::get_amd_gpu_cunter;
+use amd::get_amd_gpu_counter;
 #[cfg(target_os = "macos")]
-use apple::get_apple_gpu_cunter;
+use apple::get_apple_gpu_counter;
 #[cfg(not(target_os = "macos"))]
-use nvidia::get_nvidia_gpu_cunter;
+use nvidia::get_nvidia_gpu_counter;
 
-pub fn get_gpu_cunter(results: &mut HashMap<String, f64>) {
+pub fn get_gpu_counter(results: &mut HashMap<String, f64>) {
     #[cfg(target_os = "macos")]
-    get_apple_gpu_cunter(results);
+    get_apple_gpu_counter(results);
     #[cfg(not(target_os = "macos"))]
-    get_nvidia_gpu_cunter(results);
+    get_nvidia_gpu_counter(results);
     #[cfg(not(target_os = "macos"))]
-    get_amd_gpu_cunter(results);
+    get_amd_gpu_counter(results);
 }

--- a/src/gpu/nvidia.rs
+++ b/src/gpu/nvidia.rs
@@ -94,7 +94,7 @@ pub fn dump_all_gpu_stats(
     return Ok(());
 }
 
-pub fn get_nvidia_gpu_cunter(results: &mut HashMap<String, f64>) {
+pub fn get_nvidia_gpu_counter(results: &mut HashMap<String, f64>) {
     match NVML::init() {
         Ok(nvml) => dump_all_gpu_stats(&nvml, results).unwrap(),
         Err(_) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,8 @@ use std::thread::sleep;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use sysinfo::{CpuExt, ProcessExt, RefreshKind, System, SystemExt};
 
-// TODO: rename from french(?) "cunter" to english "counter"
-use cpu::{get_cpu_cunter, get_cpu_usage};
-use gpu::get_gpu_cunter;
+use cpu::{get_cpu_counter, get_cpu_usage};
+use gpu::get_gpu_counter;
 use memory::get_memory_usage;
 
 #[derive(Parser, Debug)]
@@ -183,9 +182,9 @@ fn execute_command(command: Vec<String>, output: Option<String>) -> std::io::Res
 fn collect(sys: &mut System, collect_gpu: bool, pid: u32, results: &mut HashMap<String, f64>) {
     get_memory_usage(sys, results);
     get_cpu_usage(sys, results);
-    get_cpu_cunter(sys, results);
+    get_cpu_counter(sys, results);
     if collect_gpu {
-        get_gpu_cunter(results);
+        get_gpu_counter(results);
     }
     // get_process_usage(sys, pid, results);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use std::thread::sleep;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use sysinfo::{CpuExt, ProcessExt, RefreshKind, System, SystemExt};
 
+// TODO: rename from french(?) "cunter" to english "counter"
 use cpu::{get_cpu_cunter, get_cpu_usage};
 use gpu::get_gpu_cunter;
 use memory::get_memory_usage;
@@ -68,7 +69,7 @@ fn main() {
 
     if interval < System::MINIMUM_CPU_UPDATE_INTERVAL {
         eprintln!(
-            "[WARNING] Interval must be at least {}ms to accurating measure CPU usage.",
+            "[WARNING] Interval must be at least {}ms to accurately measure CPU usage.",
             System::MINIMUM_CPU_UPDATE_INTERVAL.as_millis()
         );
     }


### PR DESCRIPTION
## Background

Noticed during an experiment on my Intel i7-6700HQ CPU that the energy values were way lower than expected, with one run of 150s using only 40J. Initially I thought it might be a simple wrong unit (mJ instead of J), but that didn't match up too.

## Bug Description

`Intel.rs:213` reads the energy units from the Model-Specific Register (MSR). This binary value contains three units, of which only energy is really relevant to get a correct reading of the energy consumption.

According to [Section 14.9.1 of the Intel Architectures Software Developer's Manual (Vol 3B)](https://www.intel.de/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3b-part-2-manual.pdf), the energy unit is set in bits 12:8. However the code incorrectly uses the mask `0xF000` (bits 12:15). On my chip this happens to read `0000`, with `(1/2)^0 = 1`. Coincidentally, this makes the energy unit 1, thus making it quite hard to spot. The code then incorrectly converts from uJ to J, which might be correct for the power capping framework (the unused code above it), but is actually a factor 15-61 (depends on the chip) off from the actual value.

![image](https://github.com/tdurieux/EnergiBridge/assets/15802081/d98c5464-dec2-4065-b5fe-0c0f07d95c10)

## Solution

I have rewritten the code to use the correct energy mask, as well as updating the incorrect time unit mask. Furthermore, I have added comments to make it more clear what is being done.

I hope this description makes it clear what the issue was, and how this should resolve it. For my own experiment, I will just multiply the energy readings by `1000000 * (1/2)^14` (14 being the integer value in my specific chip's unit MSR), as this should correctly convert the read values to the correct unit.
