### PR TITLE
Made energibridge attach to a process by PID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,10 @@ dependencies = [
  "once_cell",
  "serde",
  "smc",
- "sysinfo",
+ "sysinfo 0.29.10",
+ "sysinfo 0.32.0",
  "thiserror",
- "windows",
+ "windows 0.51.1",
 ]
 
 [[package]]
@@ -283,9 +284,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libloading"
@@ -296,6 +297,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -521,6 +528,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ae3f4f7d64646c46c4cae4e3f01d1c5d255c7406fdd7c7f999a94e488791"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,8 +607,18 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
 dependencies = [
- "windows-core",
+ "windows-core 0.51.1",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -597,6 +628,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ sysinfo = "0.29"
 clap = { version = "4.4.6", features = ["derive"] }
 nvml-wrapper = "^0.7.0"
 nvml-wrapper-sys = "^0.5.0"
-sysinfo = "0.29.10"
+sysinfo = "0.32.0"
 serde = { version = "1", features = ["derive"] }
 once_cell = "1"
 thiserror = "1"

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -8,14 +8,14 @@ mod intel;
 pub mod msr;
 
 use std::collections::HashMap;
-use sysinfo::{CpuExt, System, SystemExt};
+use sysinfo::System;
 
 pub fn get_number_cores(sys: &mut System) -> Option<usize> {
     return sys.physical_core_count();
 }
 
 pub fn get_cpu_usage(sys: &mut System, results: &mut HashMap<String, f64>) {
-    sys.refresh_cpu();
+    sys.refresh_cpu_all();
 
     for (i, cpu) in sys.cpus().iter().enumerate() {
         let key: String = format!("CPU_USAGE_{i}");
@@ -27,9 +27,10 @@ pub fn get_cpu_usage(sys: &mut System, results: &mut HashMap<String, f64>) {
 
 #[cfg(not(target_os = "macos"))]
 pub fn get_cpu_counter(sys: &mut System, results: &mut HashMap<String, f64>) {
-    sys.refresh_cpu();
+    sys.refresh_cpu_all();
 
-    let vendor = sys.global_cpu_info().vendor_id();
+    let cpu = sys.cpus().get(0).expect("REASON");
+    let vendor = cpu.vendor_id();
     #[cfg(not(target_os = "macos"))]
     if vendor == "GenuineIntel" {
         intel::get_intel_cpu_counter(results);

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,8 @@ fn main() {
         match cmd {
             Ok(mut child) => {
                 let start_time = Instant::now();
-    
+                sys.refresh_all();
+                println!("{}", child.id());
                 collect(&mut sys, collect_gpu, child.id(), &mut results);
                 print_header(&results, sep, &mut output);
                 let mut previous_time = SystemTime::now();

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use sysinfo::{System, SystemExt};
+use sysinfo::System;
 
 pub fn get_memory_usage(sys: &mut System, results: &mut HashMap<String, f64>) {
     sys.refresh_memory();

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use sysinfo::{System, SystemExt, ProcessExt, Pid};
+use sysinfo::{System, Pid};
 
 pub fn get_process_usage(sys: &mut System, pid: u32, results: &mut HashMap<String, f64>) {
     let p = sys.process(Pid::from(pid as usize));


### PR DESCRIPTION
I thought it would be useful to also be able to attach Energibridge to an active process.
To do so, one can now simply run energibridge and passing a process id with:  `-p <PID>`

On top of that, in the initial workflow (which uses a command spawned through energibridge) I made the command return the PID of the spawned process (not much but it makes it easy for people to attach other metric collectors, such as `perf` to the process).

Lastly, in order to get the process cpu_usage propperly, I had to update the `sys` dependency to 0.32.

I hope this is helpful for other people too.